### PR TITLE
make yum calls non-interactive

### DIFF
--- a/rbf.py
+++ b/rbf.py
@@ -435,12 +435,12 @@ class BoardTemplateParser():
         self.rbfScript.write(self.getShellExitString(BoardTemplateParser.RPMDB_INIT_ERROR))
         if len(packageGroupsString) > 0:
            self.rbfScript.write("echo [INFO ]  $0 Installing Package Groups. Please Wait\n")
-           self.rbfScript.write("yum "+ repoEnableString[0:-1] + " --installroot=" + self.workDir + " groupinstall " + packageGroupsString+" 2>> rbf.log\n")
+           self.rbfScript.write("yum "+ repoEnableString[0:-1] + " --installroot=" + self.workDir + " groupinstall -y " + packageGroupsString+" 2>> rbf.log\n")
            self.rbfScript.write(self.getShellErrorString(BoardTemplateParser.GROUP_INSTALL_ERROR))
            
         if len(packagesString) > 0:
             self.rbfScript.write("echo [INFO ]  $0 Installing Packages. Please Wait\n")
-            self.rbfScript.write("yum "+ repoEnableString[0:-1] + " --installroot=" + self.workDir + " install " + packagesString+" 2>> rbf.log\n")
+            self.rbfScript.write("yum "+ repoEnableString[0:-1] + " --installroot=" + self.workDir + " install -y " + packagesString+" 2>> rbf.log\n")
             self.rbfScript.write(self.getShellErrorString(BoardTemplateParser.PACKAGE_INSTALL_ERROR))
     
     def installKernel(self):


### PR DESCRIPTION
A small tweak.  I had to answer "y" twice during the build factory run.  The "-y" option should fix this.
